### PR TITLE
Separate settings.py to local and production settings

### DIFF
--- a/CultureAnalyzer/settings/base_settings.py
+++ b/CultureAnalyzer/settings/base_settings.py
@@ -76,9 +76,11 @@ WSGI_APPLICATION = 'CultureAnalyzer.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'culture_analyzer',
-        'HOST': 'localhost',
-        'PORT': '5432',
+        'NAME': '',
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': '',
     }
 }
 

--- a/CultureAnalyzer/settings/local.py
+++ b/CultureAnalyzer/settings/local.py
@@ -1,0 +1,14 @@
+from .base_settings import *
+
+DEBUG = True
+ALLOWED_HOSTS = ['*']
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': '',
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': '',
+    }
+}

--- a/CultureAnalyzer/settings/production.py
+++ b/CultureAnalyzer/settings/production.py
@@ -1,0 +1,3 @@
+from .base_settings import *
+
+DEBUG = False


### PR DESCRIPTION
Separated settings.py into settings package which include three files: base_settings.py, local.py and production.py.

**Where**:
base_settings.py - all app settings;
local.py - settings for local env (will be committed only with empty fields).
production.py - settings for production (for future needs)

**Notes**:
- For running application locally please use the following command: python manage.py runserver --settings=CultureAnalyzer.settings.local

- in local.py please fill the following rows:
        'NAME': '<db_name_here>',
        'USER': '<db_user_here>',
        'PASSWORD': '<db_password_here>',
        'HOST': 'localhost',
        'PORT': '5432',