### PR TITLE
Custom test runner

### DIFF
--- a/CultureAnalyzer/settings/default.py
+++ b/CultureAnalyzer/settings/default.py
@@ -122,3 +122,5 @@ CRISPY_TEMPLATE_PACK = 'bootstrap4'
 
 LOGIN_REDIRECT_URL = 'home'
 LOGIN_URL = 'login'
+
+TEST_RUNNER = 'CultureAnalyzer.tests.CustomTestRunner'

--- a/CultureAnalyzer/tests.py
+++ b/CultureAnalyzer/tests.py
@@ -1,0 +1,9 @@
+from django.test.runner import DiscoverRunner
+from django.core.management import call_command
+
+
+class CustomTestRunner(DiscoverRunner):
+    def setup_databases(self, **kwargs):
+        databases = super().setup_databases(**kwargs)
+        call_command("loaddata", "users/fixtures/fixtures.json")
+        return databases


### PR DESCRIPTION
Our created database in tests doesn't contain  user `Roles` by default. This code insert initial roles data from the file fixtures.json. I find this approach better than use fixture in every test case like this:
```python
class SomeTestCase(TestCase):
    fixtures = ('users/fixtures/fixtures.json', )
```